### PR TITLE
Add addons.mozilla.org link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Originally forked from: https://github.com/YujiSoftware/copy-text-without-select
 
 ( Icon designed by: [Mouse Runner.com](http://www.mouserunner.com/ "Mouse Runner.com, Good Content, Free Resources") )
 
+## Installation
+
+Visit https://addons.mozilla.org/en-US/firefox/addon/copy-link-with-click/
+
 ## License
 
 The MIT License (MIT)


### PR DESCRIPTION
Hi. I thought the README could do with an end-user-friendly link to install the extension. I don't know if you've uploaded it to any other browser add-on sites...

By the way, can you enable the Github Issues tab? I think it's disabled by default because this repo is a fork.